### PR TITLE
support dnsperf in update mode

### DIFF
--- a/config/bind/named.conf-authoritative
+++ b/config/bind/named.conf-authoritative
@@ -16,6 +16,7 @@ logging {
 	category default { default_stderr; };
 	category general { notice_stderr; };
 	category unmatched { null; };
+	category update { null; };
 	category security { null; };
 };
 

--- a/config/bind/zones-update-empty.conf
+++ b/config/bind/zones-update-empty.conf
@@ -1,0 +1,11 @@
+zone "example" {
+	type master;
+	file "zones/forward";
+	allow-update { any; };
+};
+
+zone "0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa." {
+	type master;
+	file "zones/reverse";
+	allow-update { any; };
+};

--- a/config/bind/zones-update-megarr.conf
+++ b/config/bind/zones-update-megarr.conf
@@ -1,0 +1,11 @@
+zone "example" {
+	type master;
+	file "zones/mega-records-dhcid";
+	allow-update { any; };
+};
+
+zone "0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa." {
+	type master;
+	file "zones/reverse-ipv6-mega-records";
+	allow-update { any; };
+};

--- a/devel/docker-compose.yaml
+++ b/devel/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     build: mongo
     ports:
       - "127.0.0.1:27017:27017"
-    command: ["--replSet", "rs"]
+    command: ["--replSet", "rs", "--logappend", "--logpath", "/dev/null"]
     hostname: "mongo"
 
   perflab_web:

--- a/lib/agents/bind.js
+++ b/lib/agents/bind.js
@@ -2,7 +2,8 @@
 
 let Agents = require('./_base'),
 	Promise = require('bluebird'),
-	fs = Promise.promisifyAll(require('fs-extra'));
+	fs = Promise.promisifyAll(require('fs-extra')),
+	path = require('path');
 
 // somewhat complicated class that's capable of running the following
 // sequence, with dependency checking and user-specified settings
@@ -13,6 +14,16 @@ let Agents = require('./_base'),
 // -  make install
 // -  named
 //
+
+async function symlinkDirContent(srcdir, destdir) {
+	const files = await fs.readdirAsync(srcdir)
+	for (const file of files) {
+		let target = `${srcdir}/${file}`
+		let newPath = `${destdir}/${file}`
+		let relLink = path.relative(destdir, target)
+		await fs.ensureSymlinkAsync(relLink, newPath)
+	}
+}
 
 class BindAgent extends Agents.Builder {
 
@@ -35,7 +46,9 @@ class BindAgent extends Agents.Builder {
 
 		let createEtc = () => fs.mkdirsAsync(this.path.etc);
 		let createRun = () => fs.mkdirsAsync(this.path.run);
-		let linkZones = () => fs.symlinkAsync('../../../zones', this.path.zone);
+		// symlink zones so zone write-back does not mangle the original files
+		let emptyZones = () => fs.emptyDirAsync(this.path.zone);
+		let linkZones = () => symlinkDirContent(`${settings.path}/zones`, this.path.zone);
 
 		let emptyRunPath = () => fs.emptyDirAsync(this.path.run);
 		let createConfig = () => fs.copyAsync(`${settings.path}/config/bind/named.conf-${config.mode}`, `${this.path.etc}/named.conf`);
@@ -50,6 +63,7 @@ class BindAgent extends Agents.Builder {
 			await emptyRunPath();
 			await createEtc();
 			await createRun();
+			await emptyZones();
 			await linkZones();
 		});
 

--- a/lib/agents/dnsperf.js
+++ b/lib/agents/dnsperf.js
@@ -21,9 +21,9 @@ class DNSPerfAgent extends Agents.Executor {
 		// look for the QPS value in the output and return it
 		let getCount = (results) => {
 			if (results.status === 0 && results.stdout) {
-				let match = results.stdout.match(/Queries per second:\s+(.*)$/m);
+				let match = results.stdout.match(/(Queries|Updates) per second:\s+(.*)$/m);
 				if (match) {
-					results.count = +match[1];
+					results.count = +match[2];
 				}
 			}
 			return results;

--- a/scripts/install-server.js
+++ b/scripts/install-server.js
@@ -4,15 +4,21 @@
 
 const settings = require('../etc/settings'),
 	child = require('child_process'),
-	fs = require('fs'),
-	util = require('util');
+	fs = require('fs');
 
 let configPath = `${settings.path}/config`;
 let zonePath = `${settings.path}/zones`;
+let querySet = `${settings.path}/queryset`
 
-let fmtConfBind = 'zone %s.example { type master; file "zones/small"; };\n';
-let fmtConfNSD = 'zone:\n\tname: %s.example\n\tzonefile: zones/small\n\n';
-let fmtConfKnot = 'zone:\n  - domain: %s.example\n    file: "zones/small"\n\n';
+function fmtConfBind(num) {
+	return `zone ${num}.example { type master; file "zones/small"; };\n`;
+}
+function fmtConfNSD(num) {
+	return `zone:\n\tname: ${num}.example\n\tzonefile: zones/small\n\n`;
+}
+function fmtConfKnot(num) {
+	return `zone:\n  - domain: ${num}.example\n    file: "zones/small"\n\n`;
+}
 
 let fmtHead = `$TTL 3600
 @		IN SOA ns1 dns 2016010101 86400 3600 86400 86400
@@ -20,11 +26,92 @@ let fmtHead = `$TTL 3600
 ns1		IN A 127.0.0.1
 		IN AAAA ::1
 `;
-let fmtRR = '%s\tIN A 127.0.0.1\n\t\tIN AAAA ::1\n';
-let fmtNS = '%s\tIN NS ns1\n';
+
+function fmtRR(num) {
+	return `dom${num}\tIN A 127.0.0.1\n\t\tIN AAAA ::1\n`;
+}
+function fmtNS(num) {
+	return `dom${num}\tIN NS ns1\n`;
+}
+
+function nToIPv6(num) {
+	// use ASCII codes of string representation instead of hex numbers
+	// ASCII provides holes between owner names instead of one dense subtree
+	let hex = Buffer.from(num.toString()).toString('hex');
+	if (hex.length > 16) {
+		throw new Error('number too large');
+	} else if (hex.length < 16) {
+		// pad to 64 bit host boundary
+		hex = hex.padStart(16, '0')
+	}
+	let ptrowner = hex.split("").reverse().join('.');  // without trailing dot
+
+	// Kea 2 uses 35-byte DHCID: this is not a valid DHCID RDATA, but the DNS server
+	// does not care so we only need a correct-ish length
+	let dhcid = `\\# 35 ${hex.padEnd(70, '0')}`
+
+	let ipv6Host = hex.match(/.{4}/g).join(':');
+	return [dhcid, ptrowner, ipv6Host]
+}
+
+function fmtAAAA(num) {
+	let [dhcid, _, ipv6Host] = nToIPv6(num)
+	return `dom${num}\tIN AAAA 2001:db8::${ipv6Host}\n\t\tIN DHCID ${dhcid}\n`;
+}
+
+function fmtPTRv6(num) {
+	let [dhcid, ptrowner, _] = nToIPv6(num)
+	return `${ptrowner}\tIN PTR dom${num}.example.\n\t\tIN DHCID ${dhcid}\n`;
+}
+
+// dnsperf -u input format, assume empty zones (prereqs should be met)
+function fmtRFC4703sec531update(num) {
+	let [dhcid, ptrowner, ipv6Host] = nToIPv6(num)
+	return `example.
+prohibit dom${num}
+add dom${num} 3600 AAAA 2001:db8::${ipv6Host}
+add dom${num} 3600 DHCID ${dhcid}
+send
+0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.
+delete ${ptrowner} PTR
+delete ${ptrowner} DHCID
+add ${ptrowner} 3600 PTR dom${num}.example.
+add ${ptrowner} 3600 DHCID ${dhcid}
+send
+`
+}
+
+// dnsperf -u input format, assume zone filled with data from
+// fmtRFC4703sec531update() and simulate IP renumbering
+function fmtRFC4703sec532update(num) {
+	let [oldDhcid, _oldPtrOwner, _oldIpv6Host] = nToIPv6(num)
+	let [_newDhcid, newPtrOwner, newIpv6Host] = nToIPv6(num + 1)
+	return `example.
+prohibit dom${num}
+add dom${num} 1800 AAAA 2001:db8:0002::${newIpv6Host}
+add dom${num} 1800 DHCID ${oldDhcid}
+send
+example.
+require dom${num} DHCID ${oldDhcid}
+delete dom${num} AAAA
+add dom${num} 1800 AAAA 2001:db8:0002::${newIpv6Host}
+send
+0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.
+delete ${newPtrOwner} PTR
+delete ${newPtrOwner} DHCID
+add ${newPtrOwner} 1800 PTR dom${num}.example.
+add ${newPtrOwner} 1800 DHCID ${oldDhcid}
+send
+`
+}
 
 console.log('Copying standard zone files');
 let res = child.spawnSync('/usr/bin/rsync', ['-av', 'zones', settings.path ]);
+console.log(res.stdout.toString());
+
+res = child.spawnSync('/usr/bin/rsync', ['-av', 'zones/small', `${zonePath}/forward` ]);
+console.log(res.stdout.toString());
+res = child.spawnSync('/usr/bin/rsync', ['-av', 'zones/small', `${zonePath}/reverse` ]);
 console.log(res.stdout.toString());
 
 console.log('Copying standard config files');
@@ -44,6 +131,12 @@ fmtWrite(1e3, fmtHead, fmtNS, `${zonePath}/kilo-delegations`);
 fmtWrite(1e6, fmtHead, fmtRR, `${zonePath}/mega-records`);
 fmtWrite(1e6, fmtHead, fmtNS, `${zonePath}/mega-delegations`);
 
+fmtWrite(1e6, fmtHead, fmtAAAA, `${zonePath}/mega-records-dhcid`);
+fmtWrite(1e6, fmtHead, fmtPTRv6, `${zonePath}/reverse-ipv6-mega-records`);
+
+fmtWrite(1e6, '', fmtRFC4703sec531update, `${querySet}/update-clean-start`);
+fmtWrite(1e6, '', fmtRFC4703sec532update, `${querySet}/update-renumber`);
+
 function fmtWrite(n, fmtHead, fmtRep, outFile) {
 	let i = 0;
 	let s = fs.createWriteStream(outFile);
@@ -51,9 +144,7 @@ function fmtWrite(n, fmtHead, fmtRep, outFile) {
 	(function write() {
 		var ok = true;
 		do {
-			var seq = ('000000' + (i++)).substr(-6);
-			var dom = 'dom' + seq;
-			var data = util.format(fmtRep, dom);
+			var data = fmtRep(i++);
 			ok = s.write(data);
 		} while (i < n && ok);
 		if (i < n) {

--- a/www/partials/config-edit.html
+++ b/www/partials/config-edit.html
@@ -78,6 +78,8 @@ pre- and post-edit results.
 			  <option value="kilo-records">1 zone, 1k A/AAAA records</option>
 			  <option value="mega-small">1M small zones</option>
 			  <option value="kilo-small">1k small zones</option>
+			  <option value="update-empty">2 zones, allow-update, empty</option>
+			  <option value="update-megarr">2 zones, allow-update, 1M names with AAAA/PTR+DHCID</option>
 			</select>
 		  </div>
 		  <div class="form-group form-group-sm" ng-if="clients && clients.length > 1">
@@ -94,6 +96,8 @@ pre- and post-edit results.
 			  <option ng-if="config.mode !== 'recursive'" value="default">Nominum default</option>
 			  <option ng-if="config.mode !== 'recursive'" value="mega-small">1M small zones, 5% NXD</option>
 			  <option ng-if="config.mode !== 'recursive'" value="kilo-small">1k small zones, 5% NXD</option>
+			  <option ng-if="config.mode !== 'recursive'" value="update-clean-start">UPDATE, expect empty zones (dnsperf -u -n 1)</option>
+			  <option ng-if="config.mode !== 'recursive'" value="update-renumber">UPDATE, expect 1M names with AAAA/PTR+DHCID and renumber all of them (dnsperf -u -n 1)</option>
 			  <option ng-if="config.mode === 'recursive'" value="mega-small">1M zones, 5% NXD</option>
 				<option ng-repeat="set in settings.querysets[config.mode]" value="{{set.file}}">{{set.name}}</option>
 			</select>

--- a/zones/small
+++ b/zones/small
@@ -1,5 +1,5 @@
 $TTL 3600
 @	IN SOA ns1.dom.example. dns.example. 2016010101 86400 3600 86400 86400
-	IN NS ns1.dom.example.
+	IN NS @
 	IN A 127.0.0.1
 	IN AAAA ::


### PR DESCRIPTION
Beware:
UPDATE operation is, by definition, stateful. Tests work correctly only if:
- State is reinitialized before each repetition:
  Checkbox "checkout before every run" must be checked.
- Each run does only a single test:
  Use "Test client runs per test" = 1.
- Each test uses the input query file at most once:
  Use "dnsperf -n 1".