### PR TITLE
Add button to download recent data in CSV format

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -326,16 +326,23 @@ class Database {
 
 			// get all runs for the given config(s) in reverse order,
 			// optionally paginated - always takes an array of config IDs
-			this.getRunsByConfigIds = async (config_ids, _, {skip, limit} = {}) => {
+			this.getRunsByConfigIds = async (config_ids, _, {skip, limit, from_datetime} = {}) => {
 				skip = +skip || 0;
 				limit = +limit || 0;
 				skip = Math.max(skip, 0);
 				limit = Math.max(limit, 0);
 				config_ids = config_ids.map(id => oid(id));
 				
+				// Build query filter with datetime constraint
+				let dateFilter = from_datetime ? new Date(from_datetime) : new Date('1970-01-02');
+				let filter = {
+					config_id: {$in: config_ids},
+					created: {$gte: dateFilter}
+				};
+				
 				// First query: get runs with pagination
 				let runs = await db.collection('run')
-					  .find({config_id: {$in: config_ids}}, {created: 1, stats: 1, commit: 1, config_id: 1})
+					  .find(filter, {created: 1, stats: 1, commit: 1, config_id: 1})
 					  .sort({created: -1})
 					  .skip(skip).limit(limit)
 					  .toArray();

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -200,13 +200,46 @@ app.controller('configListController',
 			return Object.keys($scope.selectedConfigs).filter(id => $scope.selectedConfigs[id]);
 		};
 
-		$scope.downloadSelectedCSV = function() {
+		$scope.getDateFromPeriod = function(period) {
+			const now = new Date();
+			let date;
+			
+			switch (period) {
+				case '1month':
+					date = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+					break;
+				case '3months':
+					date = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+					break;
+				case '6months':
+					date = new Date(now.getFullYear(), now.getMonth() - 6, 1);
+					break;
+				case '1year':
+					date = new Date(now.getFullYear() - 1, now.getMonth(), 1);
+					break;
+				case 'ytd':
+					date = new Date(now.getFullYear(), 0, 1);
+					break;
+				default:
+					return '';
+			}
+			
+			return date.toISOString();
+		};
+
+		$scope.downloadSelectedCSV = function(period) {
 			const selectedIds = $scope.getSelectedIds();
 			if (selectedIds.length === 0) {
 				Notify.warning('Please select at least one configuration');
 				return;
 			}
-			const url = `/api/batch/stats?ids=${selectedIds.join(',')}`;
+			
+			let url = `/api/batch/stats?ids=${selectedIds.join(',')}`;
+			if (period) {
+				const fromDatetime = $scope.getDateFromPeriod(period);
+				url += `&from_datetime=${encodeURIComponent(fromDatetime)}`;
+			}
+			
 			window.open(url, '_blank');
 		};
 

--- a/www/partials/config-list.html
+++ b/www/partials/config-list.html
@@ -51,6 +51,16 @@
 			<button class="btn btn-sm btn-success" ng-click="downloadSelectedCSV()">
 			  <span class="fas fa-download"></span> Download CSV ({{getSelectedIds().length}})
 			</button>
+			<button type="button" class="btn btn-sm btn-success dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+			  <span class="sr-only">Toggle Dropdown</span>
+			</button>
+			<div class="dropdown-menu">
+			  <a class="dropdown-item" ng-click="downloadSelectedCSV('1month')">Last Month</a>
+			  <a class="dropdown-item" ng-click="downloadSelectedCSV('3months')">Last 3 Months</a>
+			  <a class="dropdown-item" ng-click="downloadSelectedCSV('6months')">Last 6 Months</a>
+			  <a class="dropdown-item" ng-click="downloadSelectedCSV('1year')">Last Year</a>
+			  <a class="dropdown-item" ng-click="downloadSelectedCSV('ytd')">Year to Date</a>
+			</div>
 			<button class="btn btn-sm btn-warning" ng-click="archiveSelected()">
 			  <span class="fas fa-archive"></span> Archive ({{getSelectedIds().length}})
 			</button>


### PR DESCRIPTION
Sometimes downloading CSV data for long-running configs fails, likely due to the query returning too much data. But the user is usually interested only in recent data. This pull request adds the ability to request only data within one month to one year from the current date.